### PR TITLE
Allowing generating mail from text mails only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+build/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Swift Twig Mail Generator
 
-This package takes a Twig template and generates a Switf mail from this template.
+This package takes a Twig template and generates a Swift mail from this template.
 
 ## Installation
 
@@ -42,6 +42,19 @@ If you want you can add another block containing your text body. This block is o
     Body without HTML.
 {% endblock %}
 ```
+
+Also, you can create a mail with a text body only (and no HTML):
+
+```twig
+{% block subject %}
+    Your suject
+{% endblock %}
+
+{% block body_text %}
+    Body with text only.
+{% endblock %}
+```
+
 
 Now, let's create a `SwiftTwigMailTemplate` instance. This object will generate a `SwiftMail` from the twig template.
 

--- a/src/MissingBlockException.php
+++ b/src/MissingBlockException.php
@@ -14,6 +14,6 @@ class MissingBlockException extends \RuntimeException implements MailTemplateExc
         $blocksName = implode(',', $blockNames);
         $errorMsg = ($blocksName === '') ? 'No blocks found.' : 'Blocks found '.$blocksName.'.';
 
-        return new self('Your template needs a subject block and a body_html block.'.$errorMsg);
+        return new self('Your template needs a subject block and a body_html or a body_text block.'.$errorMsg);
     }
 }

--- a/tests/SwiftTwigMailTemplateTest.php
+++ b/tests/SwiftTwigMailTemplateTest.php
@@ -6,10 +6,10 @@ require_once __DIR__.'/../vendor/autoload.php';
 
 class SwiftTwigMailTemplateTest extends \PHPUnit_Framework_TestCase
 {
-    public function testUnvalidTemplate()
+    public function testInvalidTemplate()
     {
         $twigEnvironnement = new \Twig_Environment(new \Twig_Loader_Filesystem([__DIR__.'/TestTemplate']));
-        $swiftTwigMailGenerator = new SwiftTwigMailTemplate($twigEnvironnement, 'UnvalidTemplate.twig');
+        $swiftTwigMailGenerator = new SwiftTwigMailTemplate($twigEnvironnement, 'InvalidTemplate.twig');
         $this->expectException(MissingBlockException::class);
         $swiftTwigMailGenerator->renderMail();
     }
@@ -46,5 +46,26 @@ class SwiftTwigMailTemplateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['shelDon@thecodingmachine.com' => 'ShelDon'], $message->getReplyTo());
         $this->assertEquals(1, $message->getPriority());
         $this->assertEquals(999, $message->getMaxLineLength());
+    }
+
+    public function testOnlyBodyTemplate()
+    {
+        $twigEnvironnement = new \Twig_Environment(new \Twig_Loader_Filesystem([__DIR__.'/TestTemplate']));
+        $swiftTwigMailGenerator = new SwiftTwigMailTemplate($twigEnvironnement, 'OnlyTextTemplate.twig');
+
+        $message = $swiftTwigMailGenerator->renderMail(['name' => 'ShelDon']);
+
+        $this->assertEquals('This is the text body.', $message->getBody());
+    }
+
+    public function testOnlyHtmlTemplate()
+    {
+        $twigEnvironnement = new \Twig_Environment(new \Twig_Loader_Filesystem([__DIR__.'/TestTemplate']));
+        $swiftTwigMailGenerator = new SwiftTwigMailTemplate($twigEnvironnement, 'OnlyHtmlTemplate.twig');
+
+        $message = $swiftTwigMailGenerator->renderMail(['name' => 'ShelDon']);
+
+        $this->assertEquals('This is the <strong>HTML body</strong>.', $message->getBody());
+        $this->assertEquals('This is the HTML body.', $message->getChildren()[0]->getBody());
     }
 }

--- a/tests/TestTemplate/OnlyHtmlTemplate.twig
+++ b/tests/TestTemplate/OnlyHtmlTemplate.twig
@@ -1,0 +1,3 @@
+{% block subject 'Welcome to newsletter, ' ~ name %}
+
+{% block body_html %}This is the <strong>HTML body</strong>.{% endblock %}

--- a/tests/TestTemplate/OnlyTextTemplate.twig
+++ b/tests/TestTemplate/OnlyTextTemplate.twig
@@ -1,0 +1,3 @@
+{% block subject 'Welcome to newsletter, ' ~ name %}
+
+{% block body_text %}This is the text body.{% endblock %}


### PR DESCRIPTION
Allows making text only mails (with no HTML).

Also, fixes a few typos, adds a .gitignore and improves unit tests coverage of the `render` method.
